### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 
     "require": {
         "php": "^7.0",
-        "laravel/framework": "^5.5",
+        "laravel/framework": "5.5.*",
         "pragmarx/yaml": "^0.1",
         "symfony/process": "^3.3"
     },


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.