### PR TITLE
Retrieve DEFAULT_FORMAT from correct class during blade directive registration

### DIFF
--- a/src/package/ServiceProvider.php
+++ b/src/package/ServiceProvider.php
@@ -13,6 +13,7 @@ use PragmaRX\Version\Package\Console\Commands\Refresh;
 use PragmaRX\Version\Package\Console\Commands\Show;
 use PragmaRX\Version\Package\Console\Commands\Version as VersionCommand;
 use PragmaRX\Version\Package\Support\Config;
+use PragmaRX\Version\Package\Support\Constants;
 use PragmaRX\Yaml\Package\Yaml;
 
 class ServiceProvider extends IlluminateServiceProvider
@@ -125,7 +126,7 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     protected function registerBlade()
     {
-        Blade::directive($this->config->get('blade_directive', 'version'), function ($format = Version::DEFAULT_FORMAT) {
+        Blade::directive($this->config->get('blade_directive', 'version'), function ($format = Constants::DEFAULT_FORMAT) {
             return "<?php echo app('pragmarx.version')->format($format); ?>";
         });
     }


### PR DESCRIPTION
The blade registration throws a "Undefined class constant", the default state is attempting to retrieve the constant from the Version class instead of the Constants supporting class. I have updated this with a simple two line fix, I did not add tests for this as it would be overly cumbersome for a single blade directive.