### PR TITLE
Updated GitTagNotFound exception message to make it clearer

### DIFF
--- a/src/package/Support/Git.php
+++ b/src/package/Support/Git.php
@@ -43,7 +43,7 @@ class Git
         );
 
         if (empty($matches[0])) {
-            throw new GitTagNotFound('No git tags found in this repository');
+            throw new GitTagNotFound('Unable to find git tags in this repository that matches the git.version.matcher pattern in version.yml');
         }
 
         return $matches;


### PR DESCRIPTION
I encountered the same issue as described in #71 and after digging into the code, I realise that my Git tags don't really match the regex pattern described in `git.version.matcher`. I also found out from the README file [here](https://github.com/antonioribeiro/version#matching-other-version-git-tags-formats) to change it.

Actually I'd think it's best to make the exception message clearer that it's most likely an issue with the regex pattern, rather than saying no Git tags found when there may be Git tags in the repo.