### PR TITLE
Laravel 7 Compatibility (Symphony version conflict) 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.0",
         "laravel/framework": ">=5.5.33",
         "pragmarx/yaml": "^0.3",
-        "symfony/process": "^3.3|^4.0"
+        "symfony/process": "^3.3|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5|~6|~7|~8",


### PR DESCRIPTION
Laravel 7 upgraded symphony to version 5.  
This is the only package I see conflicting with Laravel 7. Please review and check for Laravel 7 Compatibility. 