### PR TITLE
Laravel 7 Compatibility (Symphony version conflict)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.0",
         "laravel/framework": ">=5.5.33",
         "pragmarx/yaml": "^0.3",
-        "symfony/process": "^3.3|^4.0"
+        "symfony/process": "^3.3|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5|~6|~7|~8",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~5|~6|~7|~8",
-        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*"
+        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Laravel 7 upgraded symphony to version 5.
Symphony and test bench are the only packages that I see conflicting with Laravel 7. 
Please review. 

