### PR TITLE
Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         "php": ">=7.0",
         "laravel/framework": ">=5.5.33",
         "pragmarx/yaml": "^1.0",
-        "symfony/process": "^3.3|^4.0|^5.0"
+        "symfony/process": "^3.3|^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5|~6|~7|~8|~9",
-        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*"
+        "orchestra/testbench": "3.4.*|3.5.*|3.6.*|3.7.*|4.*|5.*|6.*|7.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Bump in symfony/process to 6.0 and orchestra/testbench to 7.*
- Laravel 9 tests not working because of orchestra/testbench dependency in pragmarx/yaml